### PR TITLE
Look up elements once per polling cycle, to improve performance.

### DIFF
--- a/src/main/scala/im/mange/flakeless/innards/WaitForElement.scala
+++ b/src/main/scala/im/mange/flakeless/innards/WaitForElement.scala
@@ -28,10 +28,10 @@ private class WaitForElement(val command: Command,
         //TODO: we should ensure there is only one element - make configurable
         Wait.waitUpTo(config).forCondition(command,
           {
-            val result = condition(in.findElement(by))
-            val value = description(in.findElement(by))
+            val element = in.findElement(by)
+            val result = condition(element)
             if (result) context.succeeded()
-            else context.failed(value)
+            else context.failed(description(element))
             result
           },
           description(in.findElement(by))

--- a/src/main/scala/im/mange/flakeless/innards/WaitForElements.scala
+++ b/src/main/scala/im/mange/flakeless/innards/WaitForElements.scala
@@ -23,10 +23,10 @@ private class WaitForElements(val command: Command,
     (command.in, command.by) match {
       case (Some(in), Some(by)) =>
         Wait.waitUpTo(config).forCondition(command, {
-          val result = condition(in.findElements(by).asScala.toList)
-          val value = description(in.findElements(by).asScala.toList)
+          val elements = in.findElements(by).asScala.toList
+          val result = condition(elements)
           if (result) context.succeeded()
-          else context.failed(value)
+          else context.failed(description(elements))
           result
         },
           description(in.findElements(by).asScala.toList)

--- a/src/main/scala/im/mange/flakeless/innards/WaitForInteractableElement.scala
+++ b/src/main/scala/im/mange/flakeless/innards/WaitForInteractableElement.scala
@@ -27,9 +27,8 @@ private class WaitForInteractableElement(val command: Command,
         Wait.waitUpTo(config).forCondition(command, {
           val e = in.findElement(by)
           val result = (if (mustBeDisplayed) e.isDisplayed else true) && e.isEnabled && condition(e)
-          val value = description(in.findElement(by))
           if (result) context.succeeded()
-          else context.failed(value)
+          else context.failed(description(e))
           result
         },
           description(in.findElement(by)),


### PR DESCRIPTION
Shaves 10 seconds off our slowest test