### PR TITLE
Use the WebDriver as the search context for Body

### DIFF
--- a/src/main/scala/im/mange/flakeless/AssertElementAttributeContains.scala
+++ b/src/main/scala/im/mange/flakeless/AssertElementAttributeContains.scala
@@ -1,14 +1,14 @@
 package im.mange.flakeless
 
 import im.mange.flakeless.innards.{Body, Command, Description, WaitForElement}
-import org.openqa.selenium.{By, WebElement}
+import org.openqa.selenium.{By, SearchContext}
 
 object AssertElementAttributeContains {
   def apply(flakeless: Flakeless, by: By, attribute: String, expected: String): Unit = {
     apply(Body(flakeless.rawWebDriver), by, attribute, expected, Some(flakeless))
   }
 
-  def apply(in: WebElement, by: By, attribute: String, expected: String, flakeless: Option[Flakeless] = None): Unit = {
+  def apply(in: SearchContext, by: By, attribute: String, expected: String, flakeless: Option[Flakeless] = None): Unit = {
     WaitForElement(flakeless,
       Command("AssertElementAttributeContains", Some(in), Some(by), args = Map("attribute" -> attribute), expected = Some(expected)),
       description = e => Description(actual = Some((e) => e.getAttribute(attribute))).describeActual(e),

--- a/src/main/scala/im/mange/flakeless/AssertElementAttributeEquals.scala
+++ b/src/main/scala/im/mange/flakeless/AssertElementAttributeEquals.scala
@@ -1,14 +1,14 @@
 package im.mange.flakeless
 
 import im.mange.flakeless.innards.{Body, Command, Description, WaitForElement}
-import org.openqa.selenium.{By, WebElement}
+import org.openqa.selenium.{By, SearchContext}
 
 object AssertElementAttributeEquals {
   def apply(flakeless: Flakeless, by: By, attribute: String, expected: String): Unit = {
     apply(Body(flakeless.rawWebDriver), by, attribute, expected, Some(flakeless))
   }
 
-  def apply(in: WebElement, by: By, attribute: String, expected: String, flakeless: Option[Flakeless] = None): Unit = {
+  def apply(in: SearchContext, by: By, attribute: String, expected: String, flakeless: Option[Flakeless] = None): Unit = {
     WaitForElement(flakeless,
       Command("AssertElementAttributeEquals", Some(in), Some(by), args = Map("attribute" -> attribute), expected = Some(expected)),
       description = e => Description(actual = Some((e) => e.getAttribute(attribute))).describeActual(e),

--- a/src/main/scala/im/mange/flakeless/AssertElementClassContains.scala
+++ b/src/main/scala/im/mange/flakeless/AssertElementClassContains.scala
@@ -1,14 +1,14 @@
 package im.mange.flakeless
 
 import im.mange.flakeless.innards.{Body, Command, Description, WaitForElement}
-import org.openqa.selenium.{By, WebElement}
+import org.openqa.selenium.{By, SearchContext}
 
 object AssertElementClassContains {
   def apply(flakeless: Flakeless, by: By, expected: String): Unit = {
     apply(Body(flakeless.rawWebDriver), by, expected, Some(flakeless))
   }
 
-  def apply(in: WebElement, by: By, expected: String, flakeless: Option[Flakeless] = None): Unit = {
+  def apply(in: SearchContext, by: By, expected: String, flakeless: Option[Flakeless] = None): Unit = {
     val attribute = "class"
 
     WaitForElement(flakeless,

--- a/src/main/scala/im/mange/flakeless/AssertElementClassEquals.scala
+++ b/src/main/scala/im/mange/flakeless/AssertElementClassEquals.scala
@@ -1,14 +1,14 @@
 package im.mange.flakeless
 
 import im.mange.flakeless.innards.{Body, Command, Description, WaitForElement}
-import org.openqa.selenium.{By, WebElement}
+import org.openqa.selenium.{By, SearchContext}
 
 object AssertElementClassEquals {
   def apply(flakeless: Flakeless, by: By, expected: String): Unit = {
     apply(Body(flakeless.rawWebDriver), by, expected, Some(flakeless))
   }
 
-  def apply(in: WebElement, by: By, expected: String, flakeless: Option[Flakeless] = None): Unit = {
+  def apply(in: SearchContext, by: By, expected: String, flakeless: Option[Flakeless] = None): Unit = {
     val attribute = "class"
 
     WaitForElement(flakeless,

--- a/src/main/scala/im/mange/flakeless/AssertElementDisabled.scala
+++ b/src/main/scala/im/mange/flakeless/AssertElementDisabled.scala
@@ -1,14 +1,14 @@
 package im.mange.flakeless
 
 import im.mange.flakeless.innards.{AssertElementAbleness, Body}
-import org.openqa.selenium.{By, WebDriver, WebElement}
+import org.openqa.selenium.{By, SearchContext}
 
 object AssertElementDisabled {
   def apply(flakeless: Flakeless, by: By): Unit = {
     AssertElementAbleness(Body(flakeless.rawWebDriver), by, expected = false, Some(flakeless))
   }
 
-  def apply(in: WebElement, by: By, flakeless: Option[Flakeless] = None): Unit = {
+  def apply(in: SearchContext, by: By, flakeless: Option[Flakeless] = None): Unit = {
     AssertElementAbleness(in, by, expected = false, flakeless)
   }
 }

--- a/src/main/scala/im/mange/flakeless/AssertElementDisplayed.scala
+++ b/src/main/scala/im/mange/flakeless/AssertElementDisplayed.scala
@@ -1,14 +1,14 @@
 package im.mange.flakeless
 
 import im.mange.flakeless.innards.{AssertElementDisplayedness, Body}
-import org.openqa.selenium.{By, WebDriver, WebElement}
+import org.openqa.selenium.{By, SearchContext}
 
 object AssertElementDisplayed {
   def apply(flakeless: Flakeless, by: By): Unit = {
     AssertElementDisplayedness(Body(flakeless.rawWebDriver), by, expected = true, Some(flakeless))
   }
 
-  def apply(in: WebElement, by: By, flakeless: Option[Flakeless] = None): Unit = {
+  def apply(in: SearchContext, by: By, flakeless: Option[Flakeless] = None): Unit = {
     AssertElementDisplayedness(in, by, expected = true, flakeless)
   }
 }

--- a/src/main/scala/im/mange/flakeless/AssertElementEmpty.scala
+++ b/src/main/scala/im/mange/flakeless/AssertElementEmpty.scala
@@ -1,14 +1,14 @@
 package im.mange.flakeless
 
 import im.mange.flakeless.innards.{Body, Command, Description, WaitForElement}
-import org.openqa.selenium.{By, WebElement}
+import org.openqa.selenium.{By, SearchContext}
 
 object AssertElementEmpty {
   def apply(flakeless: Flakeless, by: By): Unit = {
     apply(Body(flakeless.rawWebDriver), by, Some(flakeless))
   }
 
-  def apply(in: WebElement, by: By, flakeless: Option[Flakeless] = None): Unit = {
+  def apply(in: SearchContext, by: By, flakeless: Option[Flakeless] = None): Unit = {
     WaitForElement(flakeless,
       Command("AssertElementEmpty", Some(in), Some(by), expected = Some("")),
 

--- a/src/main/scala/im/mange/flakeless/AssertElementEnabled.scala
+++ b/src/main/scala/im/mange/flakeless/AssertElementEnabled.scala
@@ -1,14 +1,14 @@
 package im.mange.flakeless
 
 import im.mange.flakeless.innards.{AssertElementAbleness, Body}
-import org.openqa.selenium.{By, WebDriver, WebElement}
+import org.openqa.selenium.{By, SearchContext}
 
 object AssertElementEnabled {
   def apply(flakeless: Flakeless, by: By): Unit = {
     AssertElementAbleness(Body(flakeless.rawWebDriver), by, expected = true, Some(flakeless))
   }
 
-  def apply(in: WebElement, by: By, flakeless: Option[Flakeless] = None): Unit = {
+  def apply(in: SearchContext, by: By, flakeless: Option[Flakeless] = None): Unit = {
     AssertElementAbleness(in, by, expected = true, flakeless)
   }
 }

--- a/src/main/scala/im/mange/flakeless/AssertElementHidden.scala
+++ b/src/main/scala/im/mange/flakeless/AssertElementHidden.scala
@@ -1,14 +1,14 @@
 package im.mange.flakeless
 
 import im.mange.flakeless.innards.{AssertElementDisplayedness, Body}
-import org.openqa.selenium.{By, WebDriver, WebElement}
+import org.openqa.selenium.{By, SearchContext}
 
 object AssertElementHidden {
   def apply(flakeless: Flakeless, by: By): Unit = {
     AssertElementDisplayedness(Body(flakeless.rawWebDriver), by, expected = false, Some(flakeless))
   }
 
-  def apply(in: WebElement, by: By, flakeless: Option[Flakeless] = None): Unit = {
+  def apply(in: SearchContext, by: By, flakeless: Option[Flakeless] = None): Unit = {
     AssertElementDisplayedness(in, by, expected = false, flakeless)
   }
 }

--- a/src/main/scala/im/mange/flakeless/AssertElementListCountEquals.scala
+++ b/src/main/scala/im/mange/flakeless/AssertElementListCountEquals.scala
@@ -1,7 +1,7 @@
 package im.mange.flakeless
 
 import im.mange.flakeless.innards.{Body, Command, WaitForElements}
-import org.openqa.selenium.{By, WebElement}
+import org.openqa.selenium.{By, SearchContext}
 
 object AssertElementListCountEquals {
   def apply(flakeless: Flakeless, by: By, expected: Int): Unit = {
@@ -9,7 +9,7 @@ object AssertElementListCountEquals {
   }
 
   //TODO: I need to be converted to a Description, just not possible yet
-  def apply(in: WebElement, by: By, expected: Int, flakeless: Option[Flakeless] = None): Unit = {
+  def apply(in: SearchContext, by: By, expected: Int, flakeless: Option[Flakeless] = None): Unit = {
     WaitForElements(flakeless,
       Command("AssertElementListCountEquals", Some(in), Some(by), expected = Some(expected.toString)),
       description = es => s"${es.size}",

--- a/src/main/scala/im/mange/flakeless/AssertElementListTextContains.scala
+++ b/src/main/scala/im/mange/flakeless/AssertElementListTextContains.scala
@@ -1,7 +1,7 @@
 package im.mange.flakeless
 
 import im.mange.flakeless.innards.{Body, Command, WaitForElements}
-import org.openqa.selenium.{By, WebElement}
+import org.openqa.selenium.{By, SearchContext}
 
 object AssertElementListTextContains {
   def apply(flakeless: Flakeless, by: By, expected: String): Unit = {
@@ -9,7 +9,7 @@ object AssertElementListTextContains {
   }
 
   //TODO: I need to be converted to a Description, just not possible yet..
-  def apply(in: WebElement, by: By, expected: String, flakeless: Option[Flakeless] = None): Unit = {
+  def apply(in: SearchContext, by: By, expected: String, flakeless: Option[Flakeless] = None): Unit = {
     WaitForElements(flakeless,
       Command("AssertElementListTextContains", Some(in), Some(by), expected = Some(expected)),
       description = es => s"${es.map(t => s"""${t.getText}""").mkString(", ")}",

--- a/src/main/scala/im/mange/flakeless/AssertElementListTextEquals.scala
+++ b/src/main/scala/im/mange/flakeless/AssertElementListTextEquals.scala
@@ -1,7 +1,7 @@
 package im.mange.flakeless
 
 import im.mange.flakeless.innards.{Body, Command, WaitForElements}
-import org.openqa.selenium.{By, WebDriver, WebElement}
+import org.openqa.selenium.{By, SearchContext}
 
 object AssertElementListTextEquals {
   def apply(flakeless: Flakeless, by: By, expected: List[String]): Unit = {
@@ -9,7 +9,7 @@ object AssertElementListTextEquals {
   }
 
   //TODO: I need to be converted to a Description, just not possible yet..
-  def apply(in: WebElement, by: By, expected: List[String], flakeless: Option[Flakeless] = None): Unit = {
+  def apply(in: SearchContext, by: By, expected: List[String], flakeless: Option[Flakeless] = None): Unit = {
     WaitForElements(flakeless,
       Command("AssertElementListTextEquals", Some(in), Some(by), expectedMany = Some(expected)),
 

--- a/src/main/scala/im/mange/flakeless/AssertElementSelected.scala
+++ b/src/main/scala/im/mange/flakeless/AssertElementSelected.scala
@@ -1,14 +1,14 @@
 package im.mange.flakeless
 
 import im.mange.flakeless.innards.{AssertElementSelectedness, Body}
-import org.openqa.selenium.{By, WebDriver, WebElement}
+import org.openqa.selenium.{By, SearchContext}
 
 object AssertElementSelected {
   def apply(flakeless: Flakeless, by: By): Unit = {
     AssertElementSelectedness(Body(flakeless.rawWebDriver), by, expected = true, Some(flakeless))
   }
 
-  def apply(in: WebElement, by: By, flakeless: Option[Flakeless] = None): Unit = {
+  def apply(in: SearchContext, by: By, flakeless: Option[Flakeless] = None): Unit = {
     AssertElementSelectedness(in, by, expected = true, flakeless)
   }
 }

--- a/src/main/scala/im/mange/flakeless/AssertElementSetTextEquals.scala
+++ b/src/main/scala/im/mange/flakeless/AssertElementSetTextEquals.scala
@@ -1,7 +1,7 @@
 package im.mange.flakeless
 
 import im.mange.flakeless.innards.{Body, Command, WaitForElements}
-import org.openqa.selenium.{By, WebElement}
+import org.openqa.selenium.{By, SearchContext}
 
 object AssertElementSetTextEquals {
   def apply(flakeless: Flakeless, by: By, expected: Set[String]): Unit = {
@@ -9,7 +9,7 @@ object AssertElementSetTextEquals {
   }
 
   //TODO: I need to be converted to a Description, just not possible yet..
-  def apply(in: WebElement, by: By, expected: Set[String], flakeless: Option[Flakeless] = None): Unit = {
+  def apply(in: SearchContext, by: By, expected: Set[String], flakeless: Option[Flakeless] = None): Unit = {
     WaitForElements(flakeless,
       Command("AssertElementSetTextEquals", Some(in), Some(by), expectedMany = Some(expected.toList)),
       description = es => s"${es.map(t => s"""${t.getText}""").mkString(", ")}",

--- a/src/main/scala/im/mange/flakeless/AssertElementTextContains.scala
+++ b/src/main/scala/im/mange/flakeless/AssertElementTextContains.scala
@@ -1,14 +1,14 @@
 package im.mange.flakeless
 
 import im.mange.flakeless.innards.{Body, Command, Description, WaitForElement}
-import org.openqa.selenium.{By, WebElement}
+import org.openqa.selenium.{By, SearchContext}
 
 object AssertElementTextContains {
   def apply(flakeless: Flakeless, by: By, expected: String): Unit = {
     apply(Body(flakeless.rawWebDriver), by, expected, Some(flakeless))
   }
 
-  def apply(in: WebElement, by: By, expected: String, flakeless: Option[Flakeless] = None): Unit = {
+  def apply(in: SearchContext, by: By, expected: String, flakeless: Option[Flakeless] = None): Unit = {
     WaitForElement(flakeless,
       Command("AssertElementTextContains", Some(in), Some(by), expected = Some(expected)),
       description = e => Description(actual = Some((e) => e.getText)).describeActual(e),

--- a/src/main/scala/im/mange/flakeless/AssertElementTextEquals.scala
+++ b/src/main/scala/im/mange/flakeless/AssertElementTextEquals.scala
@@ -1,14 +1,14 @@
 package im.mange.flakeless
 
 import im.mange.flakeless.innards.{Body, Command, Description, WaitForElement}
-import org.openqa.selenium.{By, WebElement}
+import org.openqa.selenium.{By, SearchContext}
 
 object AssertElementTextEquals {
   def apply(flakeless: Flakeless, by: By, expected: String): Unit = {
     apply(Body(flakeless.rawWebDriver), by, expected, Some(flakeless))
   }
 
-  def apply(in: WebElement, by: By, expected: String, flakeless: Option[Flakeless] = None): Unit = {
+  def apply(in: SearchContext, by: By, expected: String, flakeless: Option[Flakeless] = None): Unit = {
     WaitForElement(flakeless,
       Command("AssertElementTextEquals", Some(in), Some(by), expected = Some(expected)),
       description = e => Description(actual = Some((e) => e.getText)).describeActual(e),

--- a/src/main/scala/im/mange/flakeless/AssertElementUnselected.scala
+++ b/src/main/scala/im/mange/flakeless/AssertElementUnselected.scala
@@ -1,14 +1,14 @@
 package im.mange.flakeless
 
 import im.mange.flakeless.innards.{AssertElementSelectedness, Body}
-import org.openqa.selenium.{By, WebDriver, WebElement}
+import org.openqa.selenium.{By, SearchContext}
 
 object AssertElementUnselected {
   def apply(flakeless: Flakeless, by: By): Unit = {
     AssertElementSelectedness(Body(flakeless.rawWebDriver), by, expected = false, Some(flakeless))
   }
 
-  def apply(in: WebElement, by: By, flakeless: Option[Flakeless] = None): Unit = {
+  def apply(in: SearchContext, by: By, flakeless: Option[Flakeless] = None): Unit = {
     AssertElementSelectedness(in, by, expected = false, flakeless)
   }
 }

--- a/src/main/scala/im/mange/flakeless/ClearInputAndSendKeys.scala
+++ b/src/main/scala/im/mange/flakeless/ClearInputAndSendKeys.scala
@@ -1,7 +1,7 @@
 package im.mange.flakeless
 
 import im.mange.flakeless.innards.{Body, Command, Description, WaitForInteractableElement}
-import org.openqa.selenium.{By, WebElement}
+import org.openqa.selenium.{By, SearchContext, WebElement}
 
 //TODO: should this be Enter? it isnt in webdriver
 //TODO: this should share with SendKeys
@@ -13,12 +13,12 @@ object ClearInputAndSendKeys {
     apply(Body(flakeless.rawWebDriver), by, keysToSend, Some(flakeless))
   }
 
-  def apply(in: WebElement, by: By, keysToSend: List[CharSequence], flakeless: Option[Flakeless] = None): Unit = {
+  def apply(in: SearchContext, by: By, keysToSend: List[CharSequence], flakeless: Option[Flakeless] = None): Unit = {
     new ClearInputAndSendKeys(flakeless, in, by, keysToSend).execute()
   }
 }
 
-private class ClearInputAndSendKeys(flakeless: Option[Flakeless], in: WebElement, by: By, keysToSend: List[CharSequence]) {
+private class ClearInputAndSendKeys(flakeless: Option[Flakeless], in: SearchContext, by: By, keysToSend: List[CharSequence]) {
   def execute(): Unit = {
     WaitForInteractableElement(flakeless,
       Command("ClearInputAndSendKeys", Some(in), Some(by), args = Map("keysToSend" -> keysToSend.mkString)),

--- a/src/main/scala/im/mange/flakeless/Click.scala
+++ b/src/main/scala/im/mange/flakeless/Click.scala
@@ -1,7 +1,7 @@
 package im.mange.flakeless
 
 import im.mange.flakeless.innards.{Body, Command, Description, WaitForInteractableElement}
-import org.openqa.selenium.{By, WebElement}
+import org.openqa.selenium.{By, SearchContext}
 
 //TODO: decide if we really need the execute() stuff, we probably only need it for composites ... (i.e. integration)
 object Click {
@@ -9,12 +9,12 @@ object Click {
     apply(Body(flakeless.rawWebDriver), by, Some(flakeless))
   }
 
-  def apply(in: WebElement, by: By, flakeless: Option[Flakeless] = None): Unit = {
+  def apply(in: SearchContext, by: By, flakeless: Option[Flakeless] = None): Unit = {
     new Click(flakeless, in, by).execute()
   }
 }
 
-private class Click(flakeless: Option[Flakeless], in: WebElement, by: By) {
+private class Click(flakeless: Option[Flakeless], in: SearchContext, by: By) {
   def execute(): Unit = {
     WaitForInteractableElement(flakeless,
       Command("Click", Some(in), Some(by)),

--- a/src/main/scala/im/mange/flakeless/SendKeys.scala
+++ b/src/main/scala/im/mange/flakeless/SendKeys.scala
@@ -1,7 +1,7 @@
 package im.mange.flakeless
 
-import im.mange.flakeless.innards.{Body, Description, Command, WaitForInteractableElement}
-import org.openqa.selenium.{By, WebDriver, WebElement}
+import im.mange.flakeless.innards.{Body, Command, Description, WaitForInteractableElement}
+import org.openqa.selenium.{By, SearchContext}
 
 //TODO: should this be Enter? it isnt in webdriver
 //TODO: this should share with ClearAndSendKeys - all that is different is bool: clear
@@ -14,12 +14,12 @@ object SendKeys {
     apply(Body(flakeless.rawWebDriver), by, keysToSend, Some(flakeless))
   }
 
-  def apply(in: WebElement, by: By, keysToSend: List[CharSequence], flakeless: Option[Flakeless] = None): Unit = {
+  def apply(in: SearchContext, by: By, keysToSend: List[CharSequence], flakeless: Option[Flakeless] = None): Unit = {
     new SendKeys(flakeless, in, by, keysToSend).execute()
   }
 }
 
-private class SendKeys(flakeless: Option[Flakeless], in: WebElement, by: By, keysToSend: List[CharSequence]) {
+private class SendKeys(flakeless: Option[Flakeless], in: SearchContext, by: By, keysToSend: List[CharSequence]) {
   def execute(): Unit = {
     WaitForInteractableElement(flakeless,
       Command("SendKeys", Some(in), Some(by), args = Map("keysToSend" -> keysToSend.mkString)),

--- a/src/main/scala/im/mange/flakeless/UploadFile.scala
+++ b/src/main/scala/im/mange/flakeless/UploadFile.scala
@@ -1,7 +1,7 @@
 package im.mange.flakeless
 
 import im.mange.flakeless.innards.{Body, Command, Description, WaitForInteractableElement}
-import org.openqa.selenium.{By, OutputType, TakesScreenshot, WebElement}
+import org.openqa.selenium._
 
 //TODO: feels like I should be a factory for a private class ... see: Click
 object UploadFile {
@@ -9,7 +9,7 @@ object UploadFile {
     apply(Body(flakeless.rawWebDriver), by, filename, Some(flakeless))
   }
 
-  def apply(in: WebElement, by: By, filename: String, flakeless: Option[Flakeless] = None): Unit = {
+  def apply(in: SearchContext, by: By, filename: String, flakeless: Option[Flakeless] = None): Unit = {
     WaitForInteractableElement(flakeless,
       Command("UploadFile", Some(in), Some(by), args = Map("filename" -> filename)),
       description = e => Description().describeActual(e),

--- a/src/main/scala/im/mange/flakeless/innards/AssertElementAbleness.scala
+++ b/src/main/scala/im/mange/flakeless/innards/AssertElementAbleness.scala
@@ -1,10 +1,10 @@
 package im.mange.flakeless.innards
 
 import im.mange.flakeless.Flakeless
-import org.openqa.selenium.{By, WebDriver, WebElement}
+import org.openqa.selenium.{By, SearchContext}
 
 private [flakeless] object AssertElementAbleness {
-  def apply(in: WebElement, by: By, expected: Boolean, flakeless: Option[Flakeless]): Unit = {
+  def apply(in: SearchContext, by: By, expected: Boolean, flakeless: Option[Flakeless]): Unit = {
     WaitForElement(flakeless,
       Command(s"AssertElement${if (expected) "Enabled" else "Disabled"}", Some(in), Some(by)),
       description = e => Description(actual = Some((e) => if (e.isEnabled) "enabled" else "disabled")).describeActual(e),

--- a/src/main/scala/im/mange/flakeless/innards/AssertElementDisplayedness.scala
+++ b/src/main/scala/im/mange/flakeless/innards/AssertElementDisplayedness.scala
@@ -1,10 +1,10 @@
 package im.mange.flakeless.innards
 
 import im.mange.flakeless.Flakeless
-import org.openqa.selenium.{By, WebDriver, WebElement}
+import org.openqa.selenium.{By, SearchContext}
 
 private [flakeless] object AssertElementDisplayedness {
-  def apply(in: WebElement, by: By, expected: Boolean, flakeless: Option[Flakeless]): Unit = {
+  def apply(in: SearchContext, by: By, expected: Boolean, flakeless: Option[Flakeless]): Unit = {
     WaitForElement(flakeless,
       Command(s"AssertElement${if (expected) "Displayed" else "Hidden"}", Some(in), Some(by)),
       description = e => Description(actual = Some((e) => if (e.isDisplayed) "displayed" else "hidden")).describeActual(e),

--- a/src/main/scala/im/mange/flakeless/innards/AssertElementSelectedness.scala
+++ b/src/main/scala/im/mange/flakeless/innards/AssertElementSelectedness.scala
@@ -1,10 +1,10 @@
 package im.mange.flakeless.innards
 
 import im.mange.flakeless.Flakeless
-import org.openqa.selenium.{By, WebDriver, WebElement}
+import org.openqa.selenium.{By, SearchContext}
 
 private [flakeless] object AssertElementSelectedness {
-  def apply(in: WebElement, by: By, expected: Boolean, flakeless: Option[Flakeless]): Unit = {
+  def apply(in: SearchContext, by: By, expected: Boolean, flakeless: Option[Flakeless]): Unit = {
     WaitForElement(flakeless,
       Command(s"AssertElement${if (expected) "Selected" else "Unselected"}", Some(in), Some(by)),
       description = e => Description(actual = Some((e) => if (e.isSelected) "selected" else "unselected")).describeActual(e),

--- a/src/main/scala/im/mange/flakeless/innards/Body.scala
+++ b/src/main/scala/im/mange/flakeless/innards/Body.scala
@@ -1,9 +1,7 @@
 package im.mange.flakeless.innards
 
-import org.openqa.selenium.{By, WebDriver}
+import org.openqa.selenium.{SearchContext, WebDriver}
 
 object Body {
-  //TODO: shouldn't this be polling too?!
-  //TODO: in-fact it should probably be a Path!!
-  def apply(webDriver: WebDriver) = webDriver.findElement(By.tagName("body"))
+  def apply(webDriver: WebDriver): SearchContext = webDriver
 }

--- a/src/main/scala/im/mange/flakeless/innards/Executable.scala
+++ b/src/main/scala/im/mange/flakeless/innards/Executable.scala
@@ -1,7 +1,7 @@
 package im.mange.flakeless.innards
 
 import im.mange.flakeless.{Config, Path}
-import org.openqa.selenium.{By, WebElement}
+import org.openqa.selenium.{By, SearchContext, WebDriver}
 
 trait Executable {
   def execute(context: Context, config: Config)
@@ -16,7 +16,7 @@ case class ReportCommand(name: String, in: Option[String], bys: Seq[By],
 
 //TODO: improve rendering of options and in etc ...
 //TODO: args at end? expected's earlier?
-case class Command(name: String, in: Option[WebElement], by: Option[By],
+case class Command(name: String, in: Option[SearchContext], by: Option[By],
                    args: Map[String, String] = Map.empty,
                    expected: Option[String] = None,
                    expectedMany: Option[List[String]] = None) {
@@ -44,8 +44,8 @@ case class Command(name: String, in: Option[WebElement], by: Option[By],
       ).flatten.map(_.describe).mkString("\n| ")
   }
 
-  private def inAsString(i: WebElement) =
-    try { if (i.getTagName == "body") "body" else i.toString }
+  private def inAsString(i: SearchContext) =
+    try { if (i.isInstanceOf[WebDriver]) "body" else i.toString }
     catch { case e: Throwable => i.toString }
 
   def report = {


### PR DESCRIPTION
This cuts 10% off the test time of a typical investment bank webapp. 

The main change is in Body.scala, removing a call to findElement (instead it just looks the first element in paths off the webdriver), but required a change elsewhere to use SearchContext rather than WebElement.